### PR TITLE
Temperary Fix For Files Bigger Then 512mb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /output
+/input

--- a/bin/scan/readFile.js
+++ b/bin/scan/readFile.js
@@ -7,8 +7,8 @@ function readFile (filePath) {
         const fileContents = fs.readFileSync(filePath, 'utf8');
         return fileContents
     } catch (error) {
-        console.error('Error reading the file:', error.message);
-        process.exit(1);
+        console.error('Error reading the file', filePath, error.message);
+        return '';
     }
 };
 


### PR DESCRIPTION
When reading a files larger than 512mb, you get this " Error reading the file: Cannot create a string longer than 0x1fffffe8 characters". I removed the process.exit(1) line so the code can continue running even in the event of this error. This is a temporary fix to #1 