### PR TITLE
Forbidden is now a valid link

### DIFF
--- a/checkLink.ts
+++ b/checkLink.ts
@@ -20,11 +20,14 @@ export async function checkLink(link: string): Promise<boolean> {
     try {
         await axios.head(link, params);
     } catch (err: any) {
-        if (err.response.status !== 405) return true;
+        // Forbidden still means alive
+        if (err.response.status === 403) return false;
 
+        // If HEAD is not allowed try GET
+        if (err.response.status !== 405) return true;
         try {
             await axios.get(link, params);
-        } catch (err) {
+        } catch {
             return true;
         }
     }


### PR DESCRIPTION
A 403 code will now not be returned as a broken link. This resolves #48 and #49 .