### PR TITLE
401 links now return as working links

### DIFF
--- a/checkLink.ts
+++ b/checkLink.ts
@@ -17,13 +17,13 @@ export async function checkLink(link: string): Promise<boolean> {
         }
     };
     
-    const falsePositives: number[] = [999, 429, 403];  
+    const falsePositives: Set<number> = new Set([999, 429, 403, 401]);  
 
     try {
         await axios.head(link, params);
     } catch (err: any) {
         // If false positive, return false
-        if (falsePositives.includes(err.response.status)) return false;
+        if (falsePositives.has(err.response.status)) return false;
 
         // If HEAD is not allowed try GET
         if (err.response.status === 405) {
@@ -31,7 +31,7 @@ export async function checkLink(link: string): Promise<boolean> {
                 await axios.get(link, params);
             } catch (error: any) {
                 // If false positive, return false
-                if (falsePositives.includes(err.response.status)) return false;
+                if (falsePositives.has(err.response.status)) return false;
                 
                 return true;
             }


### PR DESCRIPTION
Example: https://gateway.us1.storjshare.io/

401 is Unauthorized. It should be a valid link because it does work for people with authoriszation, just not for link-incpector. I also changed falsePositives from an array to a set to increase performance. 

This resolves #63