### PR TITLE
Update Regex to Skip xmlns

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -57,7 +57,7 @@ export default async function linkInspector(arg: string, callback: any, path: st
         if (!/^[\x00-\x7F]*$/.test(content)) return;
                 
         // Get all the links
-        const urlRegex: RegExp = /(?<!xmlns=['"])((?<!xmlns:.*=['"])((?<!targetNamespace=['"])\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+        const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!targetNamespace=['"])(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
         const links: string[] = content.match(urlRegex) || [];
 
         const directoryIndex: number = arg.indexOf(path);

--- a/index.ts
+++ b/index.ts
@@ -57,7 +57,7 @@ export default async function linkInspector(arg: string, callback: any, path: st
         if (!/^[\x00-\x7F]*$/.test(content)) return;
                 
         // Get all the links
-        const urlRegex: RegExp = /(?<!xmlns=['"])(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+        const urlRegex: RegExp = /(?<!xmlns=['"])((?<!xmlns:.*=['"])((?<!targetNamespace=['"])\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
         const links: string[] = content.match(urlRegex) || [];
 
         const directoryIndex: number = arg.indexOf(path);

--- a/index.ts
+++ b/index.ts
@@ -57,7 +57,7 @@ export default async function linkInspector(arg: string, callback: any, path: st
         if (!/^[\x00-\x7F]*$/.test(content)) return;
                 
         // Get all the links
-        const urlRegex: RegExp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+        const urlRegex: RegExp = /(?<!xmlns=['"])(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
         const links: string[] = content.match(urlRegex) || [];
 
         const directoryIndex: number = arg.indexOf(path);


### PR DESCRIPTION
Links after xmlns are usually apart of the deep net and not the surface net. These are usually working links, but they come up as broken in this project. To reduce the number of false positives, links after xmlns=" are skipped.

This resolves #64 