### PR TITLE
Urls that end with ${ are now skipped

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -59,7 +59,7 @@ export default async function linkInspector(arg: string, callback: any, path: st
         if (!/^[\x00-\x7F]*$/.test(content)) return;
                 
         // Get all the links
-        const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!targetNamespace=['"])(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+        const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!targetNamespace=['"])(\bhttps?:\/\/(?!.*\${)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
         const links: string[] = content.match(urlRegex) || [];
 
         const directoryIndex: number = arg.indexOf(path);


### PR DESCRIPTION
Updated regex to skip urls that end with ${

Resolves #69 