### PR TITLE
Exclude { and " +

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -59,7 +59,7 @@ export default async function linkInspector(arg: string, callback: any, path: st
         if (!/^[\x00-\x7F]*$/.test(content)) return;
                 
         // Get all the links
-        const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!targetNamespace=['"])(\bhttps?:\/\/(?!.*\${)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+        const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!targetNamespace=['"])(\bhttps?:\/\/(?!.*\$)(?!.*{)(?!.*"\s\+)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
         const links: string[] = content.match(urlRegex) || [];
 
         const directoryIndex: number = arg.indexOf(path);


### PR DESCRIPTION
{ and " + is used in some programming languages to add to a url. So urls that end with these should be ignored. This resolves #74 and #73 .