### PR TITLE
CLI outputs broken link, path, and line number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `arg` can be a link, file path, or directory path. The `callback` will be gi
 import linkInspector from 'link-inspector';
 
 linkInspector('http://example.com', function (link) {
-    console.log(`Broken link found: ${link}`);
+   console.log(`Broken link found: ${link}`);
 });
 ```
 
@@ -27,8 +27,8 @@ If you want to use linkInspector on all the files in a directory:
 ```js
 import linkInspector from 'link-inspector';
 
-linkInspector('./path/to/directory', function (link, path) {
-    console.log(`Broken link ${link} found in ${path}`);
+linkInspector('./path/to/directory', function (link, path, lineNumber) {
+   console.log(`Broken link ${link} found in ${path} on line ${lineNumber}`);
 });
 ```
 

--- a/bin.ts
+++ b/bin.ts
@@ -11,7 +11,11 @@ if (args.length === 0) {
 }
 
 async function writeLink(link: string, path: string) {
+    path = path.replace(/\/\//g, '/');
+    
     console.log("Broken Link:", link);
+    console.log("Path:", path);
+    console.log("");
 
     if (path) {
         path = "output/" + path;

--- a/bin.ts
+++ b/bin.ts
@@ -10,18 +10,19 @@ if (args.length === 0) {
     console.error("no link or path given");
 }
 
-async function writeLink(link: string, path: string) {
+async function writeLink(link: string, path: string, lineNumber: number) {
     path = path.replace(/\/\//g, '/');
-    
+
     console.log("Broken Link:", link);
-    console.log("Path:", path);
+    if (path) console.log("Path:", path);
+    if (lineNumber) console.log("Line:", lineNumber);
     console.log("");
 
     if (path) {
         path = "output/" + path;
-        if (!fs.existsSync(path)) {
+        if (!fs.existsSync(path))
             fs.mkdirSync(dirname(path), { recursive: true });
-        }
+        
         fs.appendFileSync(path, link + "\n");
     }
 }
@@ -29,10 +30,11 @@ async function writeLink(link: string, path: string) {
 for (const arg of args) {
     let path: string = '';
 
-    try {new URL(arg)}
+    try { new URL(arg) }
     catch {
         path = basename(arg);
     }
 
     linkInspector(arg, writeLink, path);
+    console.log("");
 }

--- a/checkLink.ts
+++ b/checkLink.ts
@@ -23,7 +23,8 @@ export async function checkLink(link: string): Promise<boolean> {
         await axios.head(link, params);
     } catch (err: any) {
         // If false positive, return false
-        if (falsePositives.has(err.response.status)) return false;
+        if (falsePositives.has(err.response.status)) 
+            return false;
 
         // If HEAD is not allowed try GET
         if (err.response.status === 405) {
@@ -31,7 +32,8 @@ export async function checkLink(link: string): Promise<boolean> {
                 await axios.get(link, params);
             } catch (error: any) {
                 // If false positive, return false
-                if (falsePositives.has(err.response.status)) return false;
+                if (falsePositives.has(err.response.status)) 
+                    return false;
                 
                 return true;
             }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,8 @@
 import { checkLink } from "./checkLink";
 import fs from 'fs';
 
+const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!targetNamespace=['"])(\bhttps?:\/\/(?!.*\$)(?!.*{)(?!.*"\s\+)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+
 let QUEUE:Record<number, string[]> = {};
 let PROCESS: number = 0;
 let CURRENTPROCESS: number = 0;
@@ -11,21 +13,20 @@ async function runProcess(callback: any) {
     if (MAXPROCESSES <= RUNNINGPROCESSES || !QUEUE[PROCESS-1]) return;
 
     RUNNINGPROCESSES++;
-    const [link, path] = QUEUE[CURRENTPROCESS]!;
+    const [link, path, lineNumber] = QUEUE[CURRENTPROCESS]!;
     delete QUEUE[CURRENTPROCESS];
     CURRENTPROCESS++;
     
     try {
-        if (await checkLink(link!)) {
-            callback(link, path);
-        }
+        if (await checkLink(link!))
+            callback(link, path, lineNumber);
     } catch {} // Skip invalid urls
 
     RUNNINGPROCESSES--;
     runProcess(callback);
 }
 
-export default async function linkInspector(arg: string, callback: any, path: string = '') { 
+export default async function linkInspector(arg: string, callback: any, path: string) { 
     try { // If arg is a link
         new URL(arg);
         QUEUE[PROCESS] = [arg, path];
@@ -38,10 +39,12 @@ export default async function linkInspector(arg: string, callback: any, path: st
         const stats: fs.Stats = fs.lstatSync(arg);
 
         // Skip symbolic links
-        if (stats.isSymbolicLink()) return;
+        if (stats.isSymbolicLink()) 
+            return;
 
         // Skip files over 100mb
-        if (100*1024*1024 < stats.size) return
+        if (100*1024*1024 < stats.size) 
+            return
 
         // Handle directory
         if (stats.isDirectory()) {
@@ -56,22 +59,27 @@ export default async function linkInspector(arg: string, callback: any, path: st
         const content: string = fs.readFileSync(arg, 'utf8');
 
         // Skip binary files
-        if (!/^[\x00-\x7F]*$/.test(content)) return;
+        if (!/^[\x00-\x7F]*$/.test(content)) 
+            return;
                 
         // Get all the links
-        const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!targetNamespace=['"])(\bhttps?:\/\/(?!.*\$)(?!.*{)(?!.*"\s\+)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
-        const links: string[] = content.match(urlRegex) || [];
+        const lines = content.split('\n');
 
-        const directoryIndex: number = arg.indexOf(path);
-        const pathAfterDirectory: string = arg.substring(directoryIndex);
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            const matches = line!.match(urlRegex) || [];
 
-        for (const link of links) {
-            try { // Runs link inspector on each link
-                new URL(link);
-                QUEUE[PROCESS] = [link, pathAfterDirectory];
-                PROCESS++;
-                runProcess(callback);
-            } catch {}
+            const directoryIndex: number = arg.indexOf(path);
+            const pathAfterDirectory: string = arg.substring(directoryIndex);
+
+            for (const link of matches) {
+                try { // Runs link inspector on each link
+                    new URL(link);
+                    QUEUE[PROCESS] = [link, pathAfterDirectory, (i+1).toString()];
+                    PROCESS++;
+                    runProcess(callback);
+                } catch {}
+            }
         }
     } catch {
         console.error(`Error: ${arg} is not a valid link or path`);

--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,7 @@ async function runProcess(callback: any) {
     runProcess(callback);
 }
 
-export default async function linkInspector(arg: string, callback: any, path: string) { 
+export default async function linkInspector(arg: string, callback: any, path: string = '') { 
     try { // If arg is a link
         new URL(arg);
         QUEUE[PROCESS] = [arg, path];


### PR DESCRIPTION
Based on user feedback, the CLI has been changed to include file:line.

Before:
```
Broken Link: https://www.un.org/en/thispagedoesnotexist
Broken Link: https://www.un.org/en/thispagedoesnotexist
Broken Link: https://www.nasa.gov/unknown-page
```

After:
```
Broken Link: https://www.un.org/en/thispagedoesnotexist
Path: tests/links/brokenLinks
Line: 5

Broken Link: https://www.un.org/en/thispagedoesnotexist
Path: tests/links/subfolder/brokenLinks
Line: 5

Broken Link: https://www.nasa.gov/unknown-page
Path: tests/links/subfolder/brokenLinks
Line: 2
```

Thank you @kristapsk for the feedback! This resolves #76.