### PR TITLE
Follow Redirects

### DIFF
--- a/checkLink.ts
+++ b/checkLink.ts
@@ -2,50 +2,46 @@ const axios = require("axios");
 
 // Return true if link is broken
 export async function checkLink(link: string): Promise<boolean> {
-    const ignoredCodes: Set<number> = new Set([999, 429, 403, 401]);  
-    const ignoredURLs: Set<string> = new Set(['example.com']);  
+  const ignoredCodes: Set<number> = new Set([999, 429, 403, 401]);
+  const ignoredURLs: Set<string> = new Set(['example.com']);
 
-    const url = new URL(link);
-    if (ignoredURLs.has(url.host))
-        return false;
+  const url = new URL(link);
+  if (ignoredURLs.has(url.host)) {
+    return false;
+  }
 
-    const params: object = {
-        headers: {
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8", 
-            "Accept-Encoding": "gzip, deflate, br", 
-            "Accept-Language": "en-US,en;q=0.5", 
-            "Sec-Fetch-Dest": "document", 
-            "Sec-Fetch-Mode": "navigate", 
-            "Sec-Fetch-Site": "cross-site", 
-            "Sec-Fetch-User": "?1", 
-            "Upgrade-Insecure-Requests": "1", 
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0", 
-            "X-Amzn-Trace-Id": "Root=1-659f58c5-4de24ef7384486270161f185"
-        }
-    };
-    
-    try {
-        await axios.head(link, params);
-    } catch (err: any) {
-        // If false positive, return false
-        if (ignoredCodes.has(err.response.status)) 
-            return false;
+  const params: object = {
+    headers: {
+      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+      "Accept-Encoding": "gzip, deflate, br",
+      "Accept-Language": "en-US,en;q=0.5",
+      "Sec-Fetch-Dest": "document",
+      "Sec-Fetch-Mode": "navigate",
+      "Sec-Fetch-Site": "cross-site",
+      "Sec-Fetch-User": "?1",
+      "Upgrade-Insecure-Requests": "1",
+      "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+      "X-Amzn-Trace-Id": "Root=1-659f58c5-4de24ef7384486270161f185"
+    },
+  };
 
-        // If HEAD is not allowed try GET
-        if (err.response.status === 405) {
-            try {
-                await axios.get(link, params);
-            } catch (error: any) {
-                // If false positive, return false
-                if (ignoredCodes.has(err.response.status)) 
-                    return false;
-                
-                return true;
-            }
-        }
-        
-        return true;
+  try {
+    const response = await axios.get(link, params);
+    const finalUrl = new URL(response.request.res.responseUrl); // Get the final URL after any redirects
+
+    if (ignoredURLs.has(finalUrl.host)) {
+      return false;
+    }
+  } catch (err: any) {
+    // If false positive, return false
+    if (ignoredCodes.has(err.response.status)) {
+      return false;
     }
 
-    return false;
+    // If HEAD is not allowed try GET (not needed since we're using GET)
+
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
Urls that redirect to other urls are now followed. Only if the redirected url is broken will it be flagged as a broken link. 

This fixes https://app.launchdarkly.com/default/production/features/fflag_fix_front_dev_2918_labeling_filtered_paragraphs_250822_short and https://npm.pkg.github.com/
