### PR TITLE
Skip links that come after xsi:*

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { checkLink } from "./checkLink";
 import fs from 'fs';
 
-const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!targetNamespace=['"])(\bhttps?:\/\/(?!.*\$)(?!.*{)(?!.*"\s\+)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
+const urlRegex: RegExp = /(?<!xmlns=['"])(?<!xmlns:.*=['"])(?<!xsi=['"])(?<!xsi:.*=['"])(?<!targetNamespace=['"])(\bhttps?:\/\/(?!.*\$)(?!.*{)(?!.*"\s\+)[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig;
 
 let QUEUE:Record<number, string[]> = {};
 let PROCESS: number = 0;


### PR DESCRIPTION
Links after xsi are usually apart of the deep net and not the surface net. These are usually working links, but they come up as broken in this project. To reduce the number of false positives, links after xsi:* should be skipped.

Example: xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"

This resolves #87 